### PR TITLE
Various changes to improve behavior

### DIFF
--- a/customize-edit-post-flow.php
+++ b/customize-edit-post-flow.php
@@ -59,7 +59,7 @@ class WP_Customize_Post_Edit_Flow {
 	public function maybe_add_return_to_redirect( $location ) {
 		if ( isset( $_POST['customizer_return'] ) ) {
 			// todo verify _return_to_customizer_url
-			$location = add_query_arg( 'customizer_return', wp_unslash( $_POST['customizer_return'] ), $location );
+			$location = add_query_arg( 'customizer_return', urlencode( wp_unslash( $_POST['customizer_return'] ) ), $location );
 		}
 		return $location;
 	}

--- a/customize-edit-post-flow.php
+++ b/customize-edit-post-flow.php
@@ -46,6 +46,11 @@ class WP_Customize_Post_Edit_Flow {
 		add_action( 'edit_form_top', array( $this, 'post_edit_notice' ) );
 		add_filter( 'redirect_post_location', array( $this, 'maybe_add_return_to_redirect' ) );
 		add_action( 'edit_form_top', array( $this, 'maybe_add_hidden_field' ) );
+
+		// @todo Only do these on the edit post screen.
+		add_filter( 'post_link', array( $this, 'filter_permalink' ) );
+		add_filter( 'post_type_link', array( $this, 'filter_permalink' ) );
+		add_filter( 'page_link', array( $this, 'filter_permalink' ) );
 	}
 
 	public function maybe_add_hidden_field() {
@@ -102,6 +107,17 @@ class WP_Customize_Post_Edit_Flow {
 		}
 
 		return admin_url( 'customize.php' ) === sprintf( '%s://%s%s', $parsed['scheme'], $parsed['host'], $parsed['path'] );
+	}
+
+	public function filter_permalink( $url ) {
+		if ( ! $this->has_customizer_return() ) {
+			return $url;
+		}
+
+		$customizer_return = wp_unslash( $_REQUEST['customizer_return'] );
+		$customizer_return = add_query_arg( 'url', $url, $customizer_return );
+
+		return $customizer_return;
 	}
 
 	public function post_edit_notice() {

--- a/customize-edit-post-flow.php
+++ b/customize-edit-post-flow.php
@@ -148,7 +148,7 @@ class WP_Customize_Post_Edit_Flow {
 
 		// If we just came from the Customizer, show a notice of state
 		if ( $this->did_get_refered_from_customizer() ) {
-			$message = __( 'After you finish editing, you can return to customizing your site\'s appearance.' );
+			$message = __( 'After you finish editing, you can return to customizing your site\'s appearance. Please be aware that the changes you save here will go live right away without being previewed and published with your other customizations.' );
 			$message .= ' ';
 			$message .= sprintf( '<a href="%s">%s</a>', esc_url( $customizer_return ), __( 'Go back to customizing your site.' ) );
 		} else {

--- a/customize-edit-post-flow.php
+++ b/customize-edit-post-flow.php
@@ -110,15 +110,12 @@ class WP_Customize_Post_Edit_Flow {
 			return;
 		}
 
-		$post_object = get_post_type_object( get_post()->post_type );
-
 		// If we just came from the Customizer, show a notice of state
 		if ( $this->did_get_refered_from_customizer() ) {
-			$message = sprintf( __( 'After you finish editing this %s, you can return to customizing your site\'s appearance.'  ), $post_object->labels->singular_name );
+			$message = __( 'After you finish editing, you can return to customizing your site\'s appearance.' );
 		} else {
 			// otherwise, we're ready to go back.
-			$message = sprintf( __( 'You edited your %s!' ), $post_object->labels->singular_name );
-			$message .= sprintf( ' <a href="%s">%s</a>', esc_url( $_REQUEST['customizer_return'] ), __( 'Continue customizing your site.' ) );
+			$message = sprintf( ' <a href="%s">%s</a>', esc_url( $_REQUEST['customizer_return'] ), __( 'Continue customizing your site.' ) );
 		}
 		echo '<div class="notice notice-warning is-dismissible"><p>' . $message . '</p></div>';
 	}

--- a/customize-edit-post-flow.php
+++ b/customize-edit-post-flow.php
@@ -47,10 +47,28 @@ class WP_Customize_Post_Edit_Flow {
 		add_filter( 'redirect_post_location', array( $this, 'maybe_add_return_to_redirect' ) );
 		add_action( 'edit_form_top', array( $this, 'maybe_add_hidden_field' ) );
 
+		add_action( 'admin_print_styles', array( $this, 'admin_enqueue_scripts' ), 100 );
+
 		// @todo Only do these on the edit post screen.
 		add_filter( 'post_link', array( $this, 'filter_permalink' ) );
 		add_filter( 'post_type_link', array( $this, 'filter_permalink' ) );
 		add_filter( 'page_link', array( $this, 'filter_permalink' ) );
+	}
+
+	public function admin_enqueue_scripts() {
+		if ( ! $this->has_customizer_return() ) {
+			return;
+		}
+		?>
+		<style>
+			#wpcontent {
+				margin-left: 0;
+			}
+			#wpadminbar, #adminmenuwrap, #adminmenuback, #wpfooter {
+				display: none;
+			}
+		</style>
+		<?php
 	}
 
 	public function maybe_add_hidden_field() {

--- a/customize-edit-post-flow.php
+++ b/customize-edit-post-flow.php
@@ -49,17 +49,17 @@ class WP_Customize_Post_Edit_Flow {
 	}
 
 	public function maybe_add_hidden_field() {
-		if ( ! isset( $_GET['customizer_return'] ) || ! $this->is_customizer_url( $_GET['customizer_return'] ) ) {
+		if ( ! isset( $_GET['customizer_return'] ) || ! $this->is_customizer_url( wp_unslash( $_GET['customizer_return'] ) ) ) {
 			return;
 		}
 
-		printf( '<input type="hidden" name="%s" value="%s" />', 'customizer_return', esc_attr( $_GET['customizer_return'] ) );
+		printf( '<input type="hidden" name="%s" value="%s" />', 'customizer_return', esc_attr( wp_unslash( $_GET['customizer_return'] ) ) );
 	}
 
 	public function maybe_add_return_to_redirect( $location ) {
 		if ( isset( $_POST['customizer_return'] ) ) {
 			// todo verify _return_to_customizer_url
-			$location = add_query_arg( 'customizer_return', $_POST['customizer_return'], $location );
+			$location = add_query_arg( 'customizer_return', wp_unslash( $_POST['customizer_return'] ), $location );
 		}
 		return $location;
 	}
@@ -91,7 +91,7 @@ class WP_Customize_Post_Edit_Flow {
 			return false;
 		}
 
-		return $this->is_customizer_url( $_REQUEST['customizer_return'] );
+		return $this->is_customizer_url( wp_unslash( $_REQUEST['customizer_return'] ) );
 	}
 
 	private function is_customizer_url( $url ) {
@@ -115,7 +115,7 @@ class WP_Customize_Post_Edit_Flow {
 			$message = __( 'After you finish editing, you can return to customizing your site\'s appearance.' );
 		} else {
 			// otherwise, we're ready to go back.
-			$message = sprintf( ' <a href="%s">%s</a>', esc_url( $_REQUEST['customizer_return'] ), __( 'Continue customizing your site.' ) );
+			$message = sprintf( ' <a href="%s">%s</a>', esc_url( wp_unslash( $_REQUEST['customizer_return'] ) ), __( 'Continue customizing your site.' ) );
 		}
 		echo '<div class="notice notice-warning is-dismissible"><p>' . $message . '</p></div>';
 	}

--- a/customize-edit-post-flow.php
+++ b/customize-edit-post-flow.php
@@ -110,12 +110,16 @@ class WP_Customize_Post_Edit_Flow {
 			return;
 		}
 
+		$customizer_return = wp_unslash( $_REQUEST['customizer_return'] );
+
 		// If we just came from the Customizer, show a notice of state
 		if ( $this->did_get_refered_from_customizer() ) {
 			$message = __( 'After you finish editing, you can return to customizing your site\'s appearance.' );
+			$message .= ' ';
+			$message .= sprintf( '<a href="%s">%s</a>', esc_url( $customizer_return ), __( 'Go back to customizing your site.' ) );
 		} else {
 			// otherwise, we're ready to go back.
-			$message = sprintf( ' <a href="%s">%s</a>', esc_url( wp_unslash( $_REQUEST['customizer_return'] ) ), __( 'Continue customizing your site.' ) );
+			$message = sprintf( '<a href="%s">%s</a>', esc_url( $customizer_return ), __( 'Continue customizing your site.' ) );
 		}
 		echo '<div class="notice notice-warning is-dismissible"><p>' . $message . '</p></div>';
 	}

--- a/js/customize-edit-post-flow-admin.js
+++ b/js/customize-edit-post-flow-admin.js
@@ -42,6 +42,8 @@
 		$( window ).off( 'beforeunload.customize-confirm' );
 	}
 
-	api.bind( 'ready', () => api.previewer.bind( 'edit-post', api.postEditRedirect ) );
+	api.bind( 'ready', function() {
+		api.previewer.bind( 'edit-post', api.postEditRedirect );
+	} );
 
 })( this.wp, this.jQuery );

--- a/js/customize-edit-post-flow.js
+++ b/js/customize-edit-post-flow.js
@@ -17,5 +17,7 @@
 		$( '.post-edit-link.customize-unpreviewable' ).removeClass( 'customize-unpreviewable' );
 	}
 
-	api.bind( 'preview-ready', () => setTimeout( init, 100) );
+	api.bind( 'preview-ready', function(){
+		setTimeout( init, 100);
+	} );
 })( this.wp, this.jQuery );

--- a/js/customize-edit-post-flow.js
+++ b/js/customize-edit-post-flow.js
@@ -1,23 +1,27 @@
 (function( wp, $ ) {
 	var api = wp.customize;
 
-	function init() {
-		removeUnpreviewable();
-		followEditLinks();
-	}
+	// Prevent not-allowed cursor on edit-post-links.
+	api.isLinkPreviewable = ( function( originalIsLinkPreviewable ) {
+		return function( element, options ) {
+			if ( $( element ).closest( 'a' ).hasClass( 'post-edit-link' ) ) {
+				return true;
+			}
+			return originalIsLinkPreviewable.call( this, element, options );
+		};
+	} )( api.isLinkPreviewable );
 
-	function followEditLinks() {
-		$( 'body' ).on( 'click', '.post-edit-link', function( event ) {
-			api.preview.send( 'edit-post', event.target.href );
-			$( this ).css( 'cursor', 'progress' );
-		} );
-	}
+	// Send message to pane to request editing a post.
+	api.Preview.prototype.handleLinkClick = ( function( originalHandleLinkClick ) {
+		return function( event ) {
+			if ( $( event.target ).closest( 'a' ).hasClass( 'post-edit-link' ) ) {
+				event.preventDefault();
+				api.preview.send( 'edit-post', event.target.href );
+				$( event.target ).css( 'cursor', 'progress' );
+			} else {
+				originalHandleLinkClick.call( this, event );
+			}
+		};
+	} )( api.Preview.prototype.handleLinkClick );
 
-	function removeUnpreviewable() {
-		$( '.post-edit-link.customize-unpreviewable' ).removeClass( 'customize-unpreviewable' );
-	}
-
-	api.bind( 'preview-ready', function(){
-		setTimeout( init, 100);
-	} );
 })( this.wp, this.jQuery );

--- a/js/customize-edit-post-flow.js
+++ b/js/customize-edit-post-flow.js
@@ -9,6 +9,7 @@
 	function followEditLinks() {
 		$( 'body' ).on( 'click', '.post-edit-link', function( event ) {
 			api.preview.send( 'edit-post', event.target.href );
+			$( this ).css( 'cursor', 'progress' );
 		} );
 	}
 


### PR DESCRIPTION
Key changes:

* Show link back to customizer before an update is made, if they decide no change needs to be made.
* Hide admin bar, admin menu, and admin footer in edit post screen when editing post opened from customizer. The intention is to keep the user from navigating away from editing the post. This could be extended further, such as for the revisions link. In fact, `sessionStorage` could be used to store the `customizer_return` and injected in more places via JS.
* Show `cursor:progress` once clicking link in preview to show while pending changes are written to changeset.
* Add notice about post changes made not being previewable nor being part of customizations.
* Add support for edit post links added via infinite scroll.